### PR TITLE
feat(sidebar): adicionar prop items para navegação dinâmica

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -7,16 +7,18 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-const items = [
-    { title: "Dashboard", icon: LayoutDashboard, url: "/dashboard" },
-    { title: "Voluntários", icon: Users, url: "/inbox" },
-    { title: "Projetos", icon: FolderKanban, url: "/calendar" },
-    { title: "Banco de Horas", icon: Clock, url: "/search" },
-    { title: "Certificados", icon: FileBadge, url: "/settings" },
-    { title: "Relatórios", icon: FileText, url: "/settings" },
-];
 
-const Sidebar: FC = () => {
+export type SidebarItem = {
+    title: string;
+    icon: React.ElementType;
+    url: string;
+};
+
+interface SidebarProps {
+    items: SidebarItem[];
+}
+
+const Sidebar: FC<SidebarProps> = ({items}) => {
     return (
         <aside className="w-64 bg-gray-100 dark:bg-gray-900 p-4 hidden md:block">
             <div className="space-y-6">

--- a/app/routes/admin/_admin-layout.tsx
+++ b/app/routes/admin/_admin-layout.tsx
@@ -1,7 +1,7 @@
 import type { LoaderFunctionArgs } from "react-router";
 import { Outlet, useLoaderData, NavLink } from "react-router";
 import { requireRole } from "@/.server/auth/guards";
-import Sidebar from "@/components/ui/sidebar";
+import Sidebar from "@/components/Sidebar";
 import { LayoutDashboard, Users } from "lucide-react";
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -21,7 +21,7 @@ export default function AdminLayout() {
   return (
     <div className="flex h-screen bg-background">
       {/* Sidebar */}
-      <Sidebar />
+      <Sidebar items={items} />
 
       {/* Main Content */}
       <div className="flex flex-col flex-1">

--- a/app/routes/volunteer/_volunteer-layout.tsx
+++ b/app/routes/volunteer/_volunteer-layout.tsx
@@ -2,8 +2,8 @@ import type { LoaderFunctionArgs } from "react-router";
 import { Outlet, useLoaderData } from "react-router";
 import { requireRole } from "@/.server/auth/guards";
 import type { User } from "@/.server/repositories/users-repository";
-
-import Sidebar from "@/components/ui/sidebar";
+import Sidebar, { type SidebarItem } from "@/components/Sidebar";
+import { LayoutDashboard, Clock, FileBadge } from "lucide-react";
 
 export async function loader({ request }: LoaderFunctionArgs) {
   // Requer que o usuário tenha role volunteer, coordinator ou viewer
@@ -24,11 +24,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export default function VolunteerLayout() {
   const { user } = useLoaderData<typeof loader>();
-  
+  const items: SidebarItem[] = [
+    { title: "Dashboard", icon: LayoutDashboard, url: "/voluntario/dashboard" },
+    { title: "Banco de Horas", icon: Clock, url: "/voluntario/horas" },
+    { title: "Certificados", icon: FileBadge, url: "/voluntario/certificados" },
+  ];
   return (
     <div className="flex h-screen bg-background">
       {/* Sidebar */}
-      <Sidebar />
+      <Sidebar items={items} />
 
       {/* Main Content */}
       <div className="flex flex-col flex-1">


### PR DESCRIPTION
- Removi o componente Sidebar da pasta de componentes UI para a pasta de componentes principais.
-  Refatorei o Sidebar para receber os itens de navegação via props, tornando-o dinâmico.

Closes #36